### PR TITLE
Use 'apply' to pass constructor arguments

### DIFF
--- a/water.lisp
+++ b/water.lisp
@@ -6,7 +6,7 @@
      (lambda ()
        ,@b
        (when (@ this ctor)
-         (chain this (ctor arguments)))
+         (chain this ctor (apply this arguments)))
        this)))
 
 (defpsmacro defwctor (args &rest b)


### PR DESCRIPTION
Hi Nickolay! 
I've started using this project of yours, as I find it very handy and clean. I had troubles using defwctor though. 

The constructor function may have an unknown number of arguments when defwclass. In order to call it passing an 'arguments' array one must 'apply' the argument instead of calling the constructor directly.

KR,
Eric